### PR TITLE
fixed getPayload deserialization txid null error

### DIFF
--- a/src/Response/GetPayload/Response.php
+++ b/src/Response/GetPayload/Response.php
@@ -7,7 +7,7 @@ use DateTimeImmutable;
 final class Response
 {
     public function __construct(
-        public readonly string $txid,
+        public readonly ?string $txid,
         public readonly ?DateTimeImmutable $resolvedAt = null,
         public readonly ?string $dispatchedNodeType = null,
         public readonly ?string $dispatchedTo = null,


### PR DESCRIPTION
When calling the `getPayload` function with an expired, not submitted Payload, the deserialized Response threw an exception.
This happened because the txid was `null`, but the `GetPayload\Response` constructor only accepts string for `$txid`.

`Xrpl\XummSdkPhp\Response\GetPayload\Response::__construct(): Argument #1 ($txid) must be of type string, null given`

The trace went back to the deserialization of the Response. The constructor of the `GetPayload\Response` accepts only string values.

By adding a `?` we allow null values for `txid`. This is needed for cases like above, where the transaction doesn't get submitted to the XRP Ledger and therefore doesn't have a transaction hash/txid. 