### PR TITLE
Set default value of blob to `null`

### DIFF
--- a/src/Payload/CustomMeta.php
+++ b/src/Payload/CustomMeta.php
@@ -7,7 +7,7 @@ final class CustomMeta
     public function __construct(
         public readonly ?string $identifier,
         public readonly ?string $instruction,
-        public readonly ?array $blob = [],
+        public readonly ?array $blob = null,
     ) {
     }
 }


### PR DESCRIPTION
Instead of `[]`, which I thought fixed the bug before but actually
didn't.