### PR TITLE
added hex field to GetPayload Response

### DIFF
--- a/src/Response/GetPayload/Response.php
+++ b/src/Response/GetPayload/Response.php
@@ -8,6 +8,7 @@ final class Response
 {
     public function __construct(
         public readonly ?string $txid = null,
+        public readonly ?string $hex = null,
         public readonly ?DateTimeImmutable $resolvedAt = null,
         public readonly ?string $dispatchedNodeType = null,
         public readonly ?string $dispatchedTo = null,


### PR DESCRIPTION
As described in the Issue: #22 the `hex` field which contains the signed transaction blob is missing and therefore added in this pull request.