### PR TITLE
Added Pathfinding to Payload Options

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -93,6 +93,8 @@ final class FeatureContext implements Context
             isset($data['immutable']) ? (bool)$data['immutable'] : null,
             isset($data['forceAccount']) ? (bool)$data['forceAccount'] : null,
             $data['returnUrl'] ? new ReturnUrl(null, $data['returnUrl']) : null,
+            $data['signers'] ? json_decode($data['signers'], true) : null,
+            isset($data['pathfinding']) ? (bool)$data['pathfinding'] : null,
         );
     }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -93,7 +93,6 @@ final class FeatureContext implements Context
             isset($data['immutable']) ? (bool)$data['immutable'] : null,
             isset($data['forceAccount']) ? (bool)$data['forceAccount'] : null,
             $data['returnUrl'] ? new ReturnUrl(null, $data['returnUrl']) : null,
-            $data['signers'] ? json_decode($data['signers'], true) : null,
             isset($data['pathfinding']) ? (bool)$data['pathfinding'] : null,
         );
     }

--- a/src/Payload/Options.php
+++ b/src/Payload/Options.php
@@ -20,6 +20,7 @@ final class Options
         public readonly ?bool $forceAccount = null,
         public readonly ?ReturnUrl $returnUrl = null,
         public readonly ?array $signers = null,
+        public readonly ?bool $pathfinding = null,
     ) {
         if (!is_null($this->signers)) {
             foreach ($this->signers as $key => $signer) {

--- a/src/Response/GetPayload/PayloadMeta.php
+++ b/src/Response/GetPayload/PayloadMeta.php
@@ -23,6 +23,7 @@ final class PayloadMeta
         public readonly ?bool $immutable = null,
         public readonly ?string $returnUrlApp = null,
         public readonly ?string $returnUrlWeb = null,
+        public readonly ?bool $pathfinding = null,
     ) {
     }
 }

--- a/tests/Unit/Serializer/Response/CancelPayloadSerializationTest.php
+++ b/tests/Unit/Serializer/Response/CancelPayloadSerializationTest.php
@@ -36,7 +36,8 @@ final class CancelPayloadSerializationTest
     "opened_by_deeplink": null,
     "return_url_app": null,
     "return_url_web": null,
-    "is_xapp": false
+    "is_xapp": false,
+    "pathfinding": false
   },
   "custom_meta": {
     "identifier": null,

--- a/tests/Unit/Serializer/Response/GetPayloadSerializationTest.php
+++ b/tests/Unit/Serializer/Response/GetPayloadSerializationTest.php
@@ -37,7 +37,8 @@ final class GetPayloadSerializationTest extends TestCase
     "opened_by_deeplink": null,
     "return_url_app": null,
     "return_url_web": null,
-    "is_xapp": false
+    "is_xapp": false,
+    "pathfinding": false
   },
   "application": {
     "name": "Xumm PHP SDK test",
@@ -103,6 +104,7 @@ JS;
                 expired: false,
                 pushed: false,
                 isXapp: false,
+                pathfinding: false
             ),
             application: new Application(
                 name: 'Xumm PHP SDK test',

--- a/tests/helper/Mock/XummPayloadMock.php
+++ b/tests/helper/Mock/XummPayloadMock.php
@@ -35,6 +35,7 @@ final class XummPayloadMock
                 true,
                 true,
                 false,
+                false,
             ),
             new Application(
                 'cool app',


### PR DESCRIPTION
Added the pathfinding option to the payload `Options` and `PayloadMeta` response.

**Feature**: https://github.com/XRPL-Labs/XUMM-Issue-Tracker/issues/392

**Docs**:
 - https://xumm.readme.io/reference/post-payload
 - https://xumm.readme.io/reference/get-payload