### PR TITLE
Added missing property issuer to the Currency

### DIFF
--- a/src/Response/CuratedAssets/Currency.php
+++ b/src/Response/CuratedAssets/Currency.php
@@ -8,6 +8,7 @@ final class Currency
         public readonly int $id,
         public readonly int $issuerId,
         public string $currency,
+        public string $issuer,
         public string $name,
         public ?string $avatar,
         public int $shortlist,


### PR DESCRIPTION
Testing the requests directly in the API, I detected that the property is present, only in the PHP object that it is not. This fixes this issue.