### PR TITLE
PathfindingFallback and ForceNetwork payload options

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -96,7 +96,7 @@ final class FeatureContext implements Context
             isset($data['signers']) ? explode(',', $data['signers']) : null,
             isset($data['pathfinding']) ? (bool)$data['pathfinding'] : null,
             isset($data['pathfindingFallback']) ? (bool)$data['pathfindingFallback'] : null,
-            isset($data['forceNetwork']) ? $data['forceNetwork'] : null,
+            $data['forceNetwork'] ?? null,
         );
     }
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -95,6 +95,8 @@ final class FeatureContext implements Context
             $data['returnUrl'] ? new ReturnUrl(null, $data['returnUrl']) : null,
             isset($data['signers']) ? explode(',', $data['signers']) : null,
             isset($data['pathfinding']) ? (bool)$data['pathfinding'] : null,
+            isset($data['pathfindingFallback']) ? (bool)$data['pathfindingFallback'] : null,
+            isset($data['forceNetwork']) ? $data['forceNetwork'] : null,
         );
     }
 

--- a/src/Payload/Options.php
+++ b/src/Payload/Options.php
@@ -21,6 +21,8 @@ final class Options
         public readonly ?ReturnUrl $returnUrl = null,
         public readonly ?array $signers = null,
         public readonly ?bool $pathfinding = null,
+        public readonly ?bool $pathfindingFallback = null,
+        public readonly ?string $forceNetwork = null,
     ) {
         if (!is_null($this->signers)) {
             foreach ($this->signers as $key => $signer) {

--- a/src/Response/GetPayload/PayloadMeta.php
+++ b/src/Response/GetPayload/PayloadMeta.php
@@ -19,12 +19,14 @@ final class PayloadMeta
         public readonly bool $pushed,
         public readonly bool $appOpened,
         public readonly bool $isXapp,
+        public readonly bool $pathfinding,
+        public readonly bool $pathfindingFallback,
         public readonly ?bool $openedByDeeplink = null,
         public readonly ?bool $immutable = null,
         public readonly ?string $returnUrlApp = null,
         public readonly ?string $returnUrlWeb = null,
-        public readonly ?bool $pathfinding = null,
         public readonly ?array $signers = null,
+        public readonly ?string $forceNetwork = null,
     ) {
     }
 }

--- a/tests/Unit/Serializer/Response/CancelPayloadSerializationTest.php
+++ b/tests/Unit/Serializer/Response/CancelPayloadSerializationTest.php
@@ -37,7 +37,9 @@ final class CancelPayloadSerializationTest
     "return_url_app": null,
     "return_url_web": null,
     "is_xapp": false,
-    "pathfinding": false
+    "pathfinding": false,
+    "pathfinding_fallback": false,
+    "force_network": null
   },
   "custom_meta": {
     "identifier": null,

--- a/tests/Unit/Serializer/Response/GetPayloadSerializationTest.php
+++ b/tests/Unit/Serializer/Response/GetPayloadSerializationTest.php
@@ -38,7 +38,9 @@ final class GetPayloadSerializationTest extends TestCase
     "return_url_app": null,
     "return_url_web": null,
     "is_xapp": false,
-    "pathfinding": false
+    "pathfinding": false,
+    "pathfinding_fallback": false,
+    "force_network": null
   },
   "application": {
     "name": "Xumm PHP SDK test",
@@ -104,7 +106,8 @@ JS;
                 expired: false,
                 pushed: false,
                 isXapp: false,
-                pathfinding: false
+                pathfinding: false,
+                pathfindingFallback: false
             ),
             application: new Application(
                 name: 'Xumm PHP SDK test',

--- a/tests/helper/Mock/XummPayloadMock.php
+++ b/tests/helper/Mock/XummPayloadMock.php
@@ -36,8 +36,7 @@ final class XummPayloadMock
                 true,
                 false,
                 false,
-                false,
-                null,
+                false
             ),
             new Application(
                 'cool app',

--- a/tests/helper/Mock/XummPayloadMock.php
+++ b/tests/helper/Mock/XummPayloadMock.php
@@ -36,6 +36,8 @@ final class XummPayloadMock
                 true,
                 false,
                 false,
+                false,
+                null,
             ),
             new Application(
                 'cool app',


### PR DESCRIPTION
- Added `pathfinding_fallback` that allows Xumm clients < version 2.4.0 to fallback from modern pathfinding UX to a native 1:1 asset payment.
- Added `force_network` that, if set, the payload can only be opened by a device connected to the specified network. Xumm 2.5.0 and higher required.

**Docs**:
- https://xumm.readme.io/reference/post-payload
- https://xumm.readme.io/reference/get-payload