### PR TITLE
Upgrade to new mock API version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       mock-api:
-        image: synon/xumm-mock-api:1.1
+        image: synon/xumm-mock-api:1.2
         ports:
           - '8080:3000'
       mock-ws:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   mock-api:
-    image: synon/xumm-mock-api:1.1
+    image: synon/xumm-mock-api:1.2
     container_name: xumm-mock-api
     ports:
       - '8080:3000'

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -93,6 +93,7 @@ final class FeatureContext implements Context
             isset($data['immutable']) ? (bool)$data['immutable'] : null,
             isset($data['forceAccount']) ? (bool)$data['forceAccount'] : null,
             $data['returnUrl'] ? new ReturnUrl(null, $data['returnUrl']) : null,
+            isset($data['signers']) ? explode(',', $data['signers']) : null,
             isset($data['pathfinding']) ? (bool)$data['pathfinding'] : null,
         );
     }

--- a/features/create-payload.feature
+++ b/features/create-payload.feature
@@ -5,8 +5,8 @@ Feature: Create a payload
 
   Scenario: create a valid payload
     Given I create some payload options:
-    |submit|multisign|expire|returnUrl           |
-    |1    |0         |1     |https://example.corg|
+    |submit|multisign|expire|returnUrl            |signers  |
+    |1     |0         |1     |https://example.corg|foo,"bar"|
     And I add some custom meta data:
     |identifier                          |instruction   |blob          |
     |a6da5dc1-9fc2-4739-960c-5c2ce928ad4e|Please pay me?| {"foo":"bar"}|

--- a/src/Response/GetPayload/PayloadMeta.php
+++ b/src/Response/GetPayload/PayloadMeta.php
@@ -24,6 +24,7 @@ final class PayloadMeta
         public readonly ?string $returnUrlApp = null,
         public readonly ?string $returnUrlWeb = null,
         public readonly ?bool $pathfinding = null,
+        public readonly ?array $signers = null,
     ) {
     }
 }


### PR DESCRIPTION
Fixes #20 

The mock API was outdated, making it so that tests would break when up-to-date properties were added to the SDK. This fixes that.

Also adds signers data to create payload tests and adds it to get payload response, as per API docs.